### PR TITLE
Add `ReadmeCoreRenderer` and `ReadmeIntegrationRenderer`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,8 @@ classifiers = [
   "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dependencies = [
-  "pydoc-markdown==4.8.2"
+  "pydoc-markdown==4.8.2",
+  "requests"
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR adds two new renderers, `ReadmeCoreRenderer` and `ReadmeIntegrationRenderer`.

The first is meant to be used in the `haystack` core repo. It uses `hatch` to get the current version.

The second one is meant to be used in the `haystack-core-integrations` repo. It queries `PyPi` to get the latest `haystack-ai` release. It only picks stable versions so we need to wait for `2.0.0` release to start using it.

This way integrations docs will always be uploaded to the latest stable version. This might not the best approach cause of the way documentation is updated when releasing Haystack core. The current unstable branch is promoted to stable, so we lose all integration documentation changes from the branch off of the previous version and the new stable. 

This is a trade off I'm willing to make as of now, we can work around that by manually uploading the integrations docs if necessary.