### PR TITLE
add license classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ authors = [
   { name = "Massimiliano Pippi", email = "mpippi@gmail.com" },
 ]
 classifiers = [
+  "License :: OSI Approved :: Apache Software License",
   "Development Status :: 4 - Beta",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
Add license classifiers to make PyPi expose the license ([currently missing](https://pypi.org/project/haystack-pydoc-tools/)).

Related: https://github.com/deepset-ai/haystack-core-integrations/pull/1020#discussion_r1731505201