### PR TITLE
Add `setuptools` as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "pydoc-markdown==4.8.2",
   "databind<4.5.0",
   "requests",
+  "setuptools",
 ]
 
 [project.urls]


### PR DESCRIPTION
Discussed in https://github.com/deepset-ai/haystack-core-integrations/pull/1142#discussion_r1804487210

We need `pkg_resources`, which comes with `setuptools`.