### PR TITLE
feat: Add Docusaurus renderer

### DIFF
--- a/src/haystack_pydoc_tools/renderers.py
+++ b/src/haystack_pydoc_tools/renderers.py
@@ -28,7 +28,7 @@ hidden: false
 
 DOCUSAURUS_FRONTMATTER = """---
 title: {title}
-id: {id}
+id: {slug}
 description: {description}
 ---
 
@@ -265,6 +265,6 @@ class DocusaurusRenderer(Renderer):
     def _frontmatter(self) -> str:
         return DOCUSAURUS_FRONTMATTER.format(
             title=self.title,
-            id=self.id,
+            slug=self.slug,
             description=self.description,
         )

--- a/src/haystack_pydoc_tools/renderers.py
+++ b/src/haystack_pydoc_tools/renderers.py
@@ -28,7 +28,7 @@ hidden: false
 
 DOCUSAURUS_FRONTMATTER = """---
 title: {title}
-id: {slug}
+id: {id}
 description: {description}
 ---
 
@@ -265,6 +265,6 @@ class DocusaurusRenderer(Renderer):
     def _frontmatter(self) -> str:
         return DOCUSAURUS_FRONTMATTER.format(
             title=self.title,
-            slug=self.slug,
+            id=self.id,
             description=self.description,
         )


### PR DESCRIPTION
This PR adds a DocusaurusRenderer. It's simpler than ReadmeCoreRenderer because it doesn't intera.ct with any Readme API

I got the feedback from @dfokina that the following frontmatter is enough for docusaurus as a start. The id should come from what was the `slug` field before. For example, in `agents_api.yml` we have `slug: agents-api`. I renamed it to id.

```
---
title: "Creating Custom Components"
id: "custom-components"
description: "Create your own components and use them standalone or in pipelines."
---
```

Tested with 
```yaml
loaders:
  - type: haystack_pydoc_tools.loaders.CustomPythonLoader
    search_path: [../../../haystack/components/agents]
    modules: ["agent"]
    ignore_when_discovered: ["__init__"]
processors:
  - type: filter
    expression:
    documented_only: true
    do_not_filter_modules: false
    skip_empty_modules: true
  - type: smart
  - type: crossref
renderer:
  type: haystack_pydoc_tools.renderers.DocusaurusRenderer
  description: Tool-using agents with provider-agnostic chat model support.
  title: Agents
  id: agents-api
  markdown:
    descriptive_class_title: false
    classdef_code_block: false
    descriptive_module_title: true
    add_method_class_prefix: true
    add_member_class_prefix: false
    filename: agents_api.md
```

which generated 
```
---
title: Agents
id: agents-api
description: Tool-using agents with provider-agnostic chat model support.
---

<a id="agent"></a>

# Module agent

<a id="agent.Agent"></a>

## Agent

A Haystack component that implements a tool-using agent with provider-agnostic chat model support.
...
```