### PR TITLE
simplify DocusaurusRenderer by removing version; bump version

### DIFF
--- a/src/haystack_pydoc_tools/__about__.py
+++ b/src/haystack_pydoc_tools/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.6.0"
+__version__ = "0.6.1"

--- a/src/haystack_pydoc_tools/renderers.py
+++ b/src/haystack_pydoc_tools/renderers.py
@@ -239,20 +239,6 @@ class DocusaurusRenderer(Renderer):
 
     def init(self, context: Context) -> None:
         self.markdown.init(context)
-        self.version = os.environ.get("PYDOC_TOOLS_HAYSTACK_DOC_VERSION", self._doc_version())
-
-    def _doc_version(self) -> str:
-        """
-        Returns the docs version.
-        """
-        # We're assuming hatch is installed and working
-        res = subprocess.run(["hatch", "version"], capture_output=True, check=True)
-        res.check_returncode()
-        full_version = res.stdout.decode().strip()
-        major, minor = full_version.split(".")[:2]
-        if "rc0" in full_version:
-            return f"v{major}.{minor}-unstable"
-        return f"v{major}.{minor}"
 
     def render(self, modules: t.List[docspec.Module]) -> None:
         if self.markdown.filename is None:


### PR DESCRIPTION
I noticed that `DocusaurusRenderer` sets the `version` field but it is unused.
In addition, in some environments using `hatch` to get the current version can be problematic.

In this PR, I am removing the unused field.