### PR TITLE
fix: Pin setuptools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
   "pydoc-markdown==4.8.2",
   "databind<4.5.0",
   "requests",
-  "setuptools",
+  "setuptools==81.0.0",
 ]
 
 [project.urls]

--- a/src/haystack_pydoc_tools/__about__.py
+++ b/src/haystack_pydoc_tools/__about__.py
@@ -1,4 +1,4 @@
 # SPDX-FileCopyrightText: 2024-present deepset GmbH <info@deepset.ai>
 #
 # SPDX-License-Identifier: Apache-2.0
-__version__ = "0.6.3"
+__version__ = "0.6.4"


### PR DESCRIPTION
pinning setuptools to 81.0.0 because the library pkg_resources was removed in version 82.0.0 and we need pkg_resources for pydoc-markdown to work. 