### PR TITLE
ci: use hatch install action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Hatch
-        run: pip install hatch
+        uses: pypa/hatch@install
 
       - name: Build
         run: hatch build

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install Hatch
-        run: pip install -U hatch
+        uses: pypa/hatch@install
     
       - name: Ruff check
         run: hatch run fmt-check


### PR DESCRIPTION
Twin PR of https://github.com/deepset-ai/haystack/pull/10679

### Proposed Changes:
- use the official Hatch Github action instead of `pip install hatch`
  - packaged by Hatch maintainers, reliable (not affected by incompatibility with virtualenv)
  - faster than pip install: speed up on all our workflows

### How did you test it?
CI