### PR TITLE
chore: pin GitHub Actions to specific commit SHAs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
 
       - name: Install Hatch
         run: pip install hatch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
   tests:
     runs-on: ubuntu-slim
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.10"
 


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions in workflow files to immutable full-length commit SHAs instead of mutable tags (e.g. `@v3`, `@v6`)
- Used [pinact](https://github.com/suzuki-shunsuke/pinact) to automatically resolve and apply the correct SHAs
- Version tags are preserved as inline comments for readability (e.g. `# v3.6.0`)

## Motivation

Mutable tags can be silently updated by action authors, which creates a supply chain attack vector. Pinning to a specific commit SHA ensures the exact code being run never changes unexpectedly.

## Affected workflows

- `release.yml` — 1 action pinned
- `tests.yml` — 2 actions pinned

🤖 Generated with [Claude Code](https://claude.com/claude-code)